### PR TITLE
Enable gzip transfer encoding for undertow/http

### DIFF
--- a/src/main/java/org/rcsb/idmapper/frontend/UndertowFrontendImpl.java
+++ b/src/main/java/org/rcsb/idmapper/frontend/UndertowFrontendImpl.java
@@ -7,6 +7,7 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.RoutingHandler;
 import io.undertow.server.handlers.BlockingHandler;
+import io.undertow.server.handlers.encoding.EncodingHandler;
 import io.undertow.util.AttachmentKey;
 import io.undertow.util.Headers;
 import org.rcsb.idmapper.IdMapperServer;
@@ -52,9 +53,14 @@ public class UndertowFrontendImpl<T extends FrontendContext<HttpServerExchange>>
     }
 
     public void initialize() {
+        // wrap it in an encodingHandler for gzip-encoded transfer support, see https://stackoverflow.com/a/46836820
+        HttpHandler encodingHandler = new EncodingHandler.Builder().build(null)
+                .wrap(rootHandler);
+
         this.server = Undertow.builder()
                 .setServerOption(UndertowOptions.ENABLE_HTTP2, true)
-                .addHttpListener(port, "0.0.0.0", rootHandler)
+                .addHttpListener(port, "0.0.0.0")
+                .setHandler(encodingHandler)
                 .build();
     }
 


### PR DESCRIPTION
Should help when slow network connections. I've tested it between data centers and there's a noticeable difference for large responses (e.g. from `all` endpoint). Within a data center is unlikely to have much effect.