### PR TITLE
Add safeguard for zero-count collections in postInitializationCheck

### DIFF
--- a/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
@@ -371,6 +371,8 @@ public class Repository {
         if (!documentCounts.containsKey(collName))
             return String.format("Count for %s collection was not collected", collName);
         long expectedCount = documentCounts.get(collName);
+        if (expectedCount == 0)
+            return String.format("No documents found in %s collection", collName);
         if (expectedCount != actualCount)
             return String.format("Collected %d documents from %s collection. Expected total count: %d",
                     actualCount, collName, expectedCount);


### PR DESCRIPTION
Add a safeguard in postInitializationCheck to flag collections with a document count of zero as errors. This complements the existing two data validation checks and helps catch incomplete or failed data loads more reliably.