### PR TITLE
RO-5068 Refactor IDMapper service to use new groups collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <log4j.version>2.24.3</log4j.version>
         <mongodb-driver.version>5.2.0</mongodb-driver.version>
         <guava.version>32.0.0-android</guava.version>
-        <rcsb.common.version>3.1.0-ALPHA1</rcsb.common.version>
+        <rcsb.common.version>3.1.0-ALPHA2</rcsb.common.version>
         <rcsb.idmapper.client.version>0.0.11</rcsb.idmapper.client.version>
         <rcsb.mojave.model.version>1.56.0-ALPHA2</rcsb.mojave.model.version>
         <undertow.version>2.3.18.Final</undertow.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <guava.version>32.0.0-android</guava.version>
         <rcsb.common.version>3.1.0-ALPHA2</rcsb.common.version>
         <rcsb.idmapper.client.version>0.0.11</rcsb.idmapper.client.version>
-        <rcsb.mojave.model.version>1.56.0-ALPHA2</rcsb.mojave.model.version>
+        <rcsb.mojave.model.version>1.57.0-ALPHA2</rcsb.mojave.model.version>
         <undertow.version>2.3.18.Final</undertow.version>
         <rsocket.version>1.1.4</rsocket.version>
         <gson.version>2.10.1</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
         <log4j.version>2.24.3</log4j.version>
         <mongodb-driver.version>5.2.0</mongodb-driver.version>
         <guava.version>32.0.0-android</guava.version>
-        <rcsb.common.version>3.0.0</rcsb.common.version>
+        <rcsb.common.version>3.1.0-ALPHA1</rcsb.common.version>
         <rcsb.idmapper.client.version>0.0.11</rcsb.idmapper.client.version>
-        <rcsb.mojave.model.version>1.55.0</rcsb.mojave.model.version>
+        <rcsb.mojave.model.version>1.56.0-ALPHA2</rcsb.mojave.model.version>
         <undertow.version>2.3.18.Final</undertow.version>
         <rsocket.version>1.1.4</rsocket.version>
         <gson.version>2.10.1</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <guava.version>32.0.0-android</guava.version>
         <rcsb.common.version>3.1.0-ALPHA2</rcsb.common.version>
         <rcsb.idmapper.client.version>0.0.11</rcsb.idmapper.client.version>
-        <rcsb.mojave.model.version>1.57.0-ALPHA2</rcsb.mojave.model.version>
+        <rcsb.mojave.model.version>1.57.0-ALPHA4</rcsb.mojave.model.version>
         <undertow.version>2.3.18.Final</undertow.version>
         <rsocket.version>1.1.4</rsocket.version>
         <gson.version>2.10.1</gson.version>

--- a/src/main/java/org/rcsb/idmapper/backend/data/AggregationMethodProvenanceMapper.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/AggregationMethodProvenanceMapper.java
@@ -1,0 +1,51 @@
+package org.rcsb.idmapper.backend.data;
+
+import org.rcsb.idmapper.input.Input;
+import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Centralized mapper between API aggregation methods and group provenance ids in DW data.
+ */
+public final class AggregationMethodProvenanceMapper {
+    private static final EnumMap<Input.AggregationMethod, String> METHOD_TO_PROVENANCE =
+            new EnumMap<>(Input.AggregationMethod.class);
+    private static final Map<String, Input.AggregationMethod> PROVENANCE_TO_METHOD = new HashMap<>();
+
+    static {
+        register(Input.AggregationMethod.sequence_identity,
+                RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_SEQUENCE_IDENTITY.value());
+        register(Input.AggregationMethod.matching_uniprot_accession,
+                RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_UNIPROT_ACCESSION.value());
+        register(Input.AggregationMethod.matching_deposit_group_id,
+                RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_DEPOSIT_GROUP_ID.value());
+        register(Input.AggregationMethod.matching_chemical_component_id,
+                RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_CHEMICAL_COMPONENT_ID.value());
+    }
+
+    private AggregationMethodProvenanceMapper() {}
+
+    private static void register(Input.AggregationMethod method, String provenanceId) {
+        METHOD_TO_PROVENANCE.put(method, provenanceId);
+        PROVENANCE_TO_METHOD.put(provenanceId, method);
+    }
+
+    public static String toProvenanceId(Input.AggregationMethod aggregationMethod) {
+        String provenanceId = METHOD_TO_PROVENANCE.get(aggregationMethod);
+        if (provenanceId == null) {
+            throw new IllegalArgumentException("Unsupported aggregation method: " + aggregationMethod);
+        }
+        return provenanceId;
+    }
+
+    public static Input.AggregationMethod toAggregationMethod(String provenanceId) {
+        Input.AggregationMethod method = PROVENANCE_TO_METHOD.get(provenanceId);
+        if (method == null) {
+            throw new IllegalArgumentException("Unsupported provenance id: " + provenanceId);
+        }
+        return method;
+    }
+}

--- a/src/main/java/org/rcsb/idmapper/backend/data/DataProvider.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/DataProvider.java
@@ -80,10 +80,10 @@ public class DataProvider {
             );
             case DW -> List.of(
                     new ComponentsCollectionTask(MongoCollections.COLL_CHEM_COMP, r),
-                    new DepositGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA, r),
-                    new SequenceGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA, r),
-                    new UniprotGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA, r),
-                    new ChemCompGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA, r)
+                    new DepositGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA_ENTRY, r),
+                    new SequenceGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA_POLYMER_ENTITY, r),
+                    new UniprotGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA_POLYMER_ENTITY, r),
+                    new ChemCompGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA_NON_POLYMER_ENTITY, r)
             );
         };
     }

--- a/src/main/java/org/rcsb/idmapper/backend/data/DataProvider.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/DataProvider.java
@@ -80,10 +80,10 @@ public class DataProvider {
             );
             case DW -> List.of(
                     new ComponentsCollectionTask(MongoCollections.COLL_CHEM_COMP, r),
-                    new DepositGroupCollectionTask(MongoCollections.COLL_GROUP_ENTRY_DEPOSIT_GROUP, r),
-                    new SequenceGroupCollectionTask(MongoCollections.COLL_GROUP_POLYMER_ENTITY_SEQUENCE_IDENTITY, r),
-                    new UniprotGroupCollectionTask(MongoCollections.COLL_GROUP_POLYMER_ENTITY_UNIPROT_ACCESSION, r),
-                    new ChemCompGroupCollectionTask(MongoCollections.COLL_GROUP_NON_POLYMER_ENTITY_CHEMICAL_COMPONENT, r)
+                    new DepositGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA, r),
+                    new SequenceGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA, r),
+                    new UniprotGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA, r),
+                    new ChemCompGroupCollectionTask(MongoCollections.COLL_GROUP_METADATA, r)
             );
         };
     }

--- a/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
@@ -8,7 +8,6 @@ import org.rcsb.idmapper.backend.data.repository.GroupRepository;
 import org.rcsb.idmapper.backend.data.repository.StructureRepository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
-import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.*;
 
@@ -358,15 +357,15 @@ public class Repository {
             }
             case DW -> {
                 if ((error = checkCount(groupMetadataCountKey(
-                        RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_SEQUENCE_IDENTITY.value()),
+                        AggregationMethodProvenanceMapper.toProvenanceId(Input.AggregationMethod.sequence_identity)),
                         getActualCountSequenceGroups())) != null)
                     state.addError(error);
                 if ((error = checkCount(groupMetadataCountKey(
-                        RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_UNIPROT_ACCESSION.value()),
+                        AggregationMethodProvenanceMapper.toProvenanceId(Input.AggregationMethod.matching_uniprot_accession)),
                         getActualCountUniprotGroups())) != null)
                     state.addError(error);
                 if ((error = checkCount(groupMetadataCountKey(
-                        RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_DEPOSIT_GROUP_ID.value()),
+                        AggregationMethodProvenanceMapper.toProvenanceId(Input.AggregationMethod.matching_deposit_group_id)),
                         getActualCountDepositGroups())) != null)
                     state.addError(error);
             }

--- a/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
@@ -8,6 +8,7 @@ import org.rcsb.idmapper.backend.data.repository.GroupRepository;
 import org.rcsb.idmapper.backend.data.repository.StructureRepository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
+import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.*;
 
@@ -356,11 +357,17 @@ public class Repository {
                     state.addError(error);
             }
             case DW -> {
-                if ((error = checkCount(groupMetadataCountKey(Input.AggregationMethod.sequence_identity.name()), getActualCountSequenceGroups())) != null)
+                if ((error = checkCount(groupMetadataCountKey(
+                        RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_SEQUENCE_IDENTITY.value()),
+                        getActualCountSequenceGroups())) != null)
                     state.addError(error);
-                if ((error = checkCount(groupMetadataCountKey(Input.AggregationMethod.matching_uniprot_accession.name()), getActualCountUniprotGroups())) != null)
+                if ((error = checkCount(groupMetadataCountKey(
+                        RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_UNIPROT_ACCESSION.value()),
+                        getActualCountUniprotGroups())) != null)
                     state.addError(error);
-                if ((error = checkCount(groupMetadataCountKey(Input.AggregationMethod.matching_deposit_group_id.name()), getActualCountDepositGroups())) != null)
+                if ((error = checkCount(groupMetadataCountKey(
+                        RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_DEPOSIT_GROUP_ID.value()),
+                        getActualCountDepositGroups())) != null)
                     state.addError(error);
             }
             default -> throw new IllegalStateException("Unexpected value: " + dataSource);

--- a/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
@@ -7,6 +7,7 @@ import org.rcsb.idmapper.backend.data.repository.ComponentRepository;
 import org.rcsb.idmapper.backend.data.repository.GroupRepository;
 import org.rcsb.idmapper.backend.data.repository.StructureRepository;
 import org.rcsb.idmapper.input.Input;
+import org.rcsb.mojave.CoreConstants;
 
 import java.util.*;
 
@@ -355,11 +356,11 @@ public class Repository {
                     state.addError(error);
             }
             case DW -> {
-                if ((error = checkCount(MongoCollections.COLL_GROUP_POLYMER_ENTITY_SEQUENCE_IDENTITY, getActualCountSequenceGroups())) != null)
+                if ((error = checkCount(groupMetadataCountKey(Input.AggregationMethod.sequence_identity.name()), getActualCountSequenceGroups())) != null)
                     state.addError(error);
-                if ((error = checkCount(MongoCollections.COLL_GROUP_POLYMER_ENTITY_UNIPROT_ACCESSION, getActualCountUniprotGroups())) != null)
+                if ((error = checkCount(groupMetadataCountKey(Input.AggregationMethod.matching_uniprot_accession.name()), getActualCountUniprotGroups())) != null)
                     state.addError(error);
-                if ((error = checkCount(MongoCollections.COLL_GROUP_ENTRY_DEPOSIT_GROUP, getActualCountDepositGroups())) != null)
+                if ((error = checkCount(groupMetadataCountKey(Input.AggregationMethod.matching_deposit_group_id.name()), getActualCountDepositGroups())) != null)
                     state.addError(error);
             }
             default -> throw new IllegalStateException("Unexpected value: " + dataSource);
@@ -401,6 +402,11 @@ public class Repository {
     private Long getActualCountDepositGroups() {
         return group.countGroups(Input.AggregationMethod.matching_deposit_group_id);
     }
+
+    public static String groupMetadataCountKey(String provenanceId) {
+        return MongoCollections.COLL_GROUP_METADATA + "|" + CoreConstants.GROUP_PROVENANCE_ID + "=" + provenanceId;
+    }
+
     public static class State {
         private final List<String> dataErrors = new ArrayList<>();
 

--- a/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/Repository.java
@@ -410,7 +410,13 @@ public class Repository {
     }
 
     public static String groupMetadataCountKey(String provenanceId) {
-        return MongoCollections.COLL_GROUP_METADATA + "|" + CoreConstants.GROUP_PROVENANCE_ID + "=" + provenanceId;
+        Input.AggregationMethod aggregationMethod = AggregationMethodProvenanceMapper.toAggregationMethod(provenanceId);
+        String collectionName = switch (aggregationMethod) {
+            case sequence_identity, matching_uniprot_accession -> MongoCollections.COLL_GROUP_METADATA_POLYMER_ENTITY;
+            case matching_deposit_group_id -> MongoCollections.COLL_GROUP_METADATA_ENTRY;
+            case matching_chemical_component_id -> MongoCollections.COLL_GROUP_METADATA_NON_POLYMER_ENTITY;
+        };
+        return collectionName + "|" + CoreConstants.GROUP_PROVENANCE_ID + "=" + provenanceId;
     }
 
     public static class State {

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/ChemCompGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/ChemCompGroupCollectionTask.java
@@ -14,6 +14,10 @@ import java.util.List;
  * @author Yana Rose
  */
 public class ChemCompGroupCollectionTask extends CollectionTask {
+    private static final String GROUP_PROVENANCE_FIELD =
+            CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
+    private static final Document FILTER = new Document(
+            GROUP_PROVENANCE_FIELD, Input.AggregationMethod.matching_chemical_component_id.name());
 
     public ChemCompGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -36,5 +40,10 @@ public class ChemCompGroupCollectionTask extends CollectionTask {
                     .addGroupMembers(Input.AggregationMethod.matching_chemical_component_id, null, group, members);
 
         };
+    }
+
+    @Override
+    protected Document getFilter() {
+        return FILTER;
     }
 }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/ChemCompGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/ChemCompGroupCollectionTask.java
@@ -4,6 +4,7 @@ import org.bson.Document;
 import org.rcsb.idmapper.backend.data.Repository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
+import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.List;
 
@@ -14,10 +15,12 @@ import java.util.List;
  * @author Yana Rose
  */
 public class ChemCompGroupCollectionTask extends CollectionTask {
+    private static final String PROVENANCE_ID =
+            RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_CHEMICAL_COMPONENT_ID.value();
     private static final String GROUP_PROVENANCE_FIELD =
             CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
     private static final Document FILTER = new Document(
-            GROUP_PROVENANCE_FIELD, Input.AggregationMethod.matching_chemical_component_id.name());
+            GROUP_PROVENANCE_FIELD, PROVENANCE_ID);
 
     public ChemCompGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -45,5 +48,10 @@ public class ChemCompGroupCollectionTask extends CollectionTask {
     @Override
     protected Document getFilter() {
         return FILTER;
+    }
+
+    @Override
+    protected String getFilterLogDetails() {
+        return CoreConstants.GROUP_PROVENANCE_ID + "=" + PROVENANCE_ID;
     }
 }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/ChemCompGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/ChemCompGroupCollectionTask.java
@@ -3,7 +3,6 @@ package org.rcsb.idmapper.backend.data.task;
 import org.bson.Document;
 import org.rcsb.idmapper.backend.data.AggregationMethodProvenanceMapper;
 import org.rcsb.idmapper.backend.data.Repository;
-import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
 
 import java.util.List;
@@ -15,14 +14,6 @@ import java.util.List;
  * @author Yana Rose
  */
 public class ChemCompGroupCollectionTask extends CollectionTask {
-    private static final Input.AggregationMethod AGGREGATION_METHOD = Input.AggregationMethod.matching_chemical_component_id;
-    private static final String PROVENANCE_ID =
-            AggregationMethodProvenanceMapper.toProvenanceId(AGGREGATION_METHOD);
-    private static final String GROUP_PROVENANCE_FIELD =
-            CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
-    private static final Document FILTER = new Document(
-            GROUP_PROVENANCE_FIELD, PROVENANCE_ID);
-
     public ChemCompGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
                 List.of(CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS, CoreConstants.GROUP_ID),
@@ -44,15 +35,5 @@ public class ChemCompGroupCollectionTask extends CollectionTask {
                     .addGroupMembers(AggregationMethodProvenanceMapper.toAggregationMethod(provenance), null, group, members);
 
         };
-    }
-
-    @Override
-    protected Document getFilter() {
-        return FILTER;
-    }
-
-    @Override
-    protected String getFilterLogDetails() {
-        return CoreConstants.GROUP_PROVENANCE_ID + "=" + PROVENANCE_ID;
     }
 }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/ChemCompGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/ChemCompGroupCollectionTask.java
@@ -1,10 +1,10 @@
 package org.rcsb.idmapper.backend.data.task;
 
 import org.bson.Document;
+import org.rcsb.idmapper.backend.data.AggregationMethodProvenanceMapper;
 import org.rcsb.idmapper.backend.data.Repository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
-import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.List;
 
@@ -15,8 +15,9 @@ import java.util.List;
  * @author Yana Rose
  */
 public class ChemCompGroupCollectionTask extends CollectionTask {
+    private static final Input.AggregationMethod AGGREGATION_METHOD = Input.AggregationMethod.matching_chemical_component_id;
     private static final String PROVENANCE_ID =
-            RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_CHEMICAL_COMPONENT_ID.value();
+            AggregationMethodProvenanceMapper.toProvenanceId(AGGREGATION_METHOD);
     private static final String GROUP_PROVENANCE_FIELD =
             CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
     private static final Document FILTER = new Document(
@@ -40,7 +41,7 @@ public class ChemCompGroupCollectionTask extends CollectionTask {
 
             repository.getGroupRepository().addGroupProvenance(group, provenance);
             repository.getGroupRepository()
-                    .addGroupMembers(Input.AggregationMethod.matching_chemical_component_id, null, group, members);
+                    .addGroupMembers(AggregationMethodProvenanceMapper.toAggregationMethod(provenance), null, group, members);
 
         };
     }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/CollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/CollectionTask.java
@@ -60,6 +60,7 @@ public abstract class CollectionTask {
 
     public Flux<Runnable> findDocuments(final MongoDatabase db) {
         Document filter = getFilter();
+        String logTarget = getLogTarget(filter);
         Publisher<Document> publisher = filter == null
                 ? db.getCollection(collectionName)
                 .find()
@@ -68,21 +69,22 @@ public abstract class CollectionTask {
                 .find(filter)
                 .projection(fields(excludeId(), include(includeFields)));
         return Flux.from(publisher)
-                .doOnSubscribe(s -> logger.info("Subscribed document task to collection [ {} ]", collectionName))
+                .doOnSubscribe(s -> logger.info("Subscribed document task to collection [ {} ]", logTarget))
                 //TODO replace with async debug or remove entirely before prod
 //                .doOnNext(d -> logger.info("Processing document from [ {} ]", collectionName))
                 .doOnError(t -> logger.error(t.getMessage()))
-                .doOnComplete(() -> logger.info("Processed documents from [ {} ] collection ", collectionName))
+                .doOnComplete(() -> logger.info("Processed documents from [ {} ] collection ", logTarget))
                 .map(this::createDocumentRunnable);
     }
 
     public Mono<Runnable> countDocuments(final MongoDatabase db) {
         Document filter = getFilter();
+        String logTarget = getLogTarget(filter);
         return Mono.from(filter == null
                         ? db.getCollection(collectionName).countDocuments()
                         : db.getCollection(collectionName).countDocuments(filter))
-                .doOnSubscribe(s -> logger.info("Subscribed count task to collection [ {} ]", collectionName))
-                .doOnSuccess(count -> logger.info("Collection [ {} ] has [ {} ] documents", collectionName, count))
+                .doOnSubscribe(s -> logger.info("Subscribed count task to collection [ {} ]", logTarget))
+                .doOnSuccess(count -> logger.info("Collection [ {} ] has [ {} ] documents", logTarget, count))
                 .doOnError(t -> logger.error(t.getMessage()))
                 .map(this::createCountRunnable);
     }
@@ -91,6 +93,16 @@ public abstract class CollectionTask {
 
     protected Document getFilter() {
         return null;
+    }
+
+    private String getLogTarget(Document filter) {
+        return filter == null
+                ? collectionName
+                : collectionName + " | " + getFilterLogDetails();
+    }
+
+    protected String getFilterLogDetails() {
+        return "filter_applied";
     }
 
     public Runnable createCountRunnable(Long count) {

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/CollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/CollectionTask.java
@@ -59,8 +59,13 @@ public abstract class CollectionTask {
     }
 
     public Flux<Runnable> findDocuments(final MongoDatabase db) {
-        Publisher<Document> publisher = db.getCollection(collectionName)
+        Document filter = getFilter();
+        Publisher<Document> publisher = filter == null
+                ? db.getCollection(collectionName)
                 .find()
+                .projection(fields(excludeId(), include(includeFields)))
+                : db.getCollection(collectionName)
+                .find(filter)
                 .projection(fields(excludeId(), include(includeFields)));
         return Flux.from(publisher)
                 .doOnSubscribe(s -> logger.info("Subscribed document task to collection [ {} ]", collectionName))
@@ -72,7 +77,10 @@ public abstract class CollectionTask {
     }
 
     public Mono<Runnable> countDocuments(final MongoDatabase db) {
-        return Mono.from(db.getCollection(collectionName).countDocuments())
+        Document filter = getFilter();
+        return Mono.from(filter == null
+                        ? db.getCollection(collectionName).countDocuments()
+                        : db.getCollection(collectionName).countDocuments(filter))
                 .doOnSubscribe(s -> logger.info("Subscribed count task to collection [ {} ]", collectionName))
                 .doOnSuccess(count -> logger.info("Collection [ {} ] has [ {} ] documents", collectionName, count))
                 .doOnError(t -> logger.error(t.getMessage()))
@@ -80,6 +88,10 @@ public abstract class CollectionTask {
     }
 
     abstract Runnable createDocumentRunnable(Document d);
+
+    protected Document getFilter() {
+        return null;
+    }
 
     public Runnable createCountRunnable(Long count) {
         return () -> repository.addCount(collectionName, count);

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
@@ -58,7 +58,7 @@ public class DepositGroupCollectionTask extends CollectionTask {
     @Override
     public Runnable createCountRunnable(Long count) {
         return () -> repository.addCount(
-                Repository.groupMetadataCountKey(Input.AggregationMethod.matching_deposit_group_id.name()),
+                Repository.groupMetadataCountKey(PROVENANCE_ID),
                 count
         );
     }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
@@ -1,10 +1,10 @@
 package org.rcsb.idmapper.backend.data.task;
 
 import org.bson.Document;
+import org.rcsb.idmapper.backend.data.AggregationMethodProvenanceMapper;
 import org.rcsb.idmapper.backend.data.Repository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
-import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.List;
 
@@ -15,8 +15,9 @@ import java.util.List;
  * @author Yana Rose
  */
 public class DepositGroupCollectionTask extends CollectionTask {
+    private static final Input.AggregationMethod AGGREGATION_METHOD = Input.AggregationMethod.matching_deposit_group_id;
     private static final String PROVENANCE_ID =
-            RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_DEPOSIT_GROUP_ID.value();
+            AggregationMethodProvenanceMapper.toProvenanceId(AGGREGATION_METHOD);
     private static final String GROUP_PROVENANCE_FIELD =
             CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
     private static final Document FILTER = new Document(
@@ -40,7 +41,7 @@ public class DepositGroupCollectionTask extends CollectionTask {
 
             repository.getGroupRepository().addGroupProvenance(group, provenance);
             repository.getGroupRepository()
-                    .addGroupMembers(Input.AggregationMethod.matching_deposit_group_id, null, group, members);
+                    .addGroupMembers(AggregationMethodProvenanceMapper.toAggregationMethod(provenance), null, group, members);
 
         };
     }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
@@ -4,6 +4,7 @@ import org.bson.Document;
 import org.rcsb.idmapper.backend.data.Repository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
+import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.List;
 
@@ -14,10 +15,12 @@ import java.util.List;
  * @author Yana Rose
  */
 public class DepositGroupCollectionTask extends CollectionTask {
+    private static final String PROVENANCE_ID =
+            RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_DEPOSIT_GROUP_ID.value();
     private static final String GROUP_PROVENANCE_FIELD =
             CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
     private static final Document FILTER = new Document(
-            GROUP_PROVENANCE_FIELD, Input.AggregationMethod.matching_deposit_group_id.name());
+            GROUP_PROVENANCE_FIELD, PROVENANCE_ID);
 
     public DepositGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -45,6 +48,11 @@ public class DepositGroupCollectionTask extends CollectionTask {
     @Override
     protected Document getFilter() {
         return FILTER;
+    }
+
+    @Override
+    protected String getFilterLogDetails() {
+        return CoreConstants.GROUP_PROVENANCE_ID + "=" + PROVENANCE_ID;
     }
 
     @Override

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
@@ -18,10 +18,6 @@ public class DepositGroupCollectionTask extends CollectionTask {
     private static final Input.AggregationMethod AGGREGATION_METHOD = Input.AggregationMethod.matching_deposit_group_id;
     private static final String PROVENANCE_ID =
             AggregationMethodProvenanceMapper.toProvenanceId(AGGREGATION_METHOD);
-    private static final String GROUP_PROVENANCE_FIELD =
-            CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
-    private static final Document FILTER = new Document(
-            GROUP_PROVENANCE_FIELD, PROVENANCE_ID);
 
     public DepositGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -44,16 +40,6 @@ public class DepositGroupCollectionTask extends CollectionTask {
                     .addGroupMembers(AggregationMethodProvenanceMapper.toAggregationMethod(provenance), null, group, members);
 
         };
-    }
-
-    @Override
-    protected Document getFilter() {
-        return FILTER;
-    }
-
-    @Override
-    protected String getFilterLogDetails() {
-        return CoreConstants.GROUP_PROVENANCE_ID + "=" + PROVENANCE_ID;
     }
 
     @Override

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/DepositGroupCollectionTask.java
@@ -14,6 +14,10 @@ import java.util.List;
  * @author Yana Rose
  */
 public class DepositGroupCollectionTask extends CollectionTask {
+    private static final String GROUP_PROVENANCE_FIELD =
+            CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
+    private static final Document FILTER = new Document(
+            GROUP_PROVENANCE_FIELD, Input.AggregationMethod.matching_deposit_group_id.name());
 
     public DepositGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -36,5 +40,18 @@ public class DepositGroupCollectionTask extends CollectionTask {
                     .addGroupMembers(Input.AggregationMethod.matching_deposit_group_id, null, group, members);
 
         };
+    }
+
+    @Override
+    protected Document getFilter() {
+        return FILTER;
+    }
+
+    @Override
+    public Runnable createCountRunnable(Long count) {
+        return () -> repository.addCount(
+                Repository.groupMetadataCountKey(Input.AggregationMethod.matching_deposit_group_id.name()),
+                count
+        );
     }
 }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/SequenceGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/SequenceGroupCollectionTask.java
@@ -4,6 +4,7 @@ import org.bson.Document;
 import org.rcsb.idmapper.backend.data.Repository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
+import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.List;
 
@@ -14,14 +15,12 @@ import java.util.List;
  * @author Yana Rose
  */
 public class SequenceGroupCollectionTask extends CollectionTask {
+    private static final String PROVENANCE_ID =
+            RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_SEQUENCE_IDENTITY.value();
     private static final String GROUP_PROVENANCE_FIELD =
             CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
     private static final Document FILTER = new Document(
-            GROUP_PROVENANCE_FIELD,
-            new Document("$in", List.of(
-                    Input.AggregationMethod.sequence_identity.name(),
-                    "match_sequence_identity"
-            )));
+            GROUP_PROVENANCE_FIELD, PROVENANCE_ID);
 
     public SequenceGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -52,6 +51,11 @@ public class SequenceGroupCollectionTask extends CollectionTask {
     @Override
     protected Document getFilter() {
         return FILTER;
+    }
+
+    @Override
+    protected String getFilterLogDetails() {
+        return CoreConstants.GROUP_PROVENANCE_ID + "=" + PROVENANCE_ID;
     }
 
     @Override

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/SequenceGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/SequenceGroupCollectionTask.java
@@ -1,10 +1,10 @@
 package org.rcsb.idmapper.backend.data.task;
 
 import org.bson.Document;
+import org.rcsb.idmapper.backend.data.AggregationMethodProvenanceMapper;
 import org.rcsb.idmapper.backend.data.Repository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
-import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.List;
 
@@ -15,8 +15,9 @@ import java.util.List;
  * @author Yana Rose
  */
 public class SequenceGroupCollectionTask extends CollectionTask {
+    private static final Input.AggregationMethod AGGREGATION_METHOD = Input.AggregationMethod.sequence_identity;
     private static final String PROVENANCE_ID =
-            RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_SEQUENCE_IDENTITY.value();
+            AggregationMethodProvenanceMapper.toProvenanceId(AGGREGATION_METHOD);
     private static final String GROUP_PROVENANCE_FIELD =
             CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
     private static final Document FILTER = new Document(
@@ -44,7 +45,7 @@ public class SequenceGroupCollectionTask extends CollectionTask {
 
             repository.getGroupRepository().addGroupProvenance(group, provenance);
             repository.getGroupRepository()
-                    .addGroupMembers(Input.AggregationMethod.sequence_identity, cutoff, group, members);
+                    .addGroupMembers(AggregationMethodProvenanceMapper.toAggregationMethod(provenance), cutoff, group, members);
         };
     }
 

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/SequenceGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/SequenceGroupCollectionTask.java
@@ -61,7 +61,7 @@ public class SequenceGroupCollectionTask extends CollectionTask {
     @Override
     public Runnable createCountRunnable(Long count) {
         return () -> repository.addCount(
-                Repository.groupMetadataCountKey(Input.AggregationMethod.sequence_identity.name()),
+                Repository.groupMetadataCountKey(PROVENANCE_ID),
                 count
         );
     }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/SequenceGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/SequenceGroupCollectionTask.java
@@ -14,6 +14,14 @@ import java.util.List;
  * @author Yana Rose
  */
 public class SequenceGroupCollectionTask extends CollectionTask {
+    private static final String GROUP_PROVENANCE_FIELD =
+            CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
+    private static final Document FILTER = new Document(
+            GROUP_PROVENANCE_FIELD,
+            new Document("$in", List.of(
+                    Input.AggregationMethod.sequence_identity.name(),
+                    "match_sequence_identity"
+            )));
 
     public SequenceGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -39,5 +47,18 @@ public class SequenceGroupCollectionTask extends CollectionTask {
             repository.getGroupRepository()
                     .addGroupMembers(Input.AggregationMethod.sequence_identity, cutoff, group, members);
         };
+    }
+
+    @Override
+    protected Document getFilter() {
+        return FILTER;
+    }
+
+    @Override
+    public Runnable createCountRunnable(Long count) {
+        return () -> repository.addCount(
+                Repository.groupMetadataCountKey(Input.AggregationMethod.sequence_identity.name()),
+                count
+        );
     }
 }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/UniprotGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/UniprotGroupCollectionTask.java
@@ -4,6 +4,7 @@ import org.bson.Document;
 import org.rcsb.idmapper.backend.data.Repository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
+import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.List;
 
@@ -14,10 +15,12 @@ import java.util.List;
  * @author Yana Rose
  */
 public class UniprotGroupCollectionTask extends CollectionTask {
+    private static final String PROVENANCE_ID =
+            RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_UNIPROT_ACCESSION.value();
     private static final String GROUP_PROVENANCE_FIELD =
             CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
     private static final Document FILTER = new Document(
-            GROUP_PROVENANCE_FIELD, Input.AggregationMethod.matching_uniprot_accession.name());
+            GROUP_PROVENANCE_FIELD, PROVENANCE_ID);
 
     public UniprotGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -44,6 +47,11 @@ public class UniprotGroupCollectionTask extends CollectionTask {
     @Override
     protected Document getFilter() {
         return FILTER;
+    }
+
+    @Override
+    protected String getFilterLogDetails() {
+        return CoreConstants.GROUP_PROVENANCE_ID + "=" + PROVENANCE_ID;
     }
 
     @Override

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/UniprotGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/UniprotGroupCollectionTask.java
@@ -57,7 +57,7 @@ public class UniprotGroupCollectionTask extends CollectionTask {
     @Override
     public Runnable createCountRunnable(Long count) {
         return () -> repository.addCount(
-                Repository.groupMetadataCountKey(Input.AggregationMethod.matching_uniprot_accession.name()),
+                Repository.groupMetadataCountKey(PROVENANCE_ID),
                 count
         );
     }

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/UniprotGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/UniprotGroupCollectionTask.java
@@ -1,10 +1,10 @@
 package org.rcsb.idmapper.backend.data.task;
 
 import org.bson.Document;
+import org.rcsb.idmapper.backend.data.AggregationMethodProvenanceMapper;
 import org.rcsb.idmapper.backend.data.Repository;
 import org.rcsb.idmapper.input.Input;
 import org.rcsb.mojave.CoreConstants;
-import org.rcsb.mojave.enumeration.RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId;
 
 import java.util.List;
 
@@ -15,8 +15,9 @@ import java.util.List;
  * @author Yana Rose
  */
 public class UniprotGroupCollectionTask extends CollectionTask {
+    private static final Input.AggregationMethod AGGREGATION_METHOD = Input.AggregationMethod.matching_uniprot_accession;
     private static final String PROVENANCE_ID =
-            RcsbGroupProvenanceContainerIdentifiersGroupProvenanceId.PROVENANCE_MATCHING_UNIPROT_ACCESSION.value();
+            AggregationMethodProvenanceMapper.toProvenanceId(AGGREGATION_METHOD);
     private static final String GROUP_PROVENANCE_FIELD =
             CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
     private static final Document FILTER = new Document(
@@ -40,7 +41,7 @@ public class UniprotGroupCollectionTask extends CollectionTask {
 
             repository.getGroupRepository().addGroupProvenance(group, provenance);
             repository.getGroupRepository()
-                    .addGroupMembers(Input.AggregationMethod.matching_uniprot_accession, null, group, members);
+                    .addGroupMembers(AggregationMethodProvenanceMapper.toAggregationMethod(provenance), null, group, members);
         };
     }
 

--- a/src/main/java/org/rcsb/idmapper/backend/data/task/UniprotGroupCollectionTask.java
+++ b/src/main/java/org/rcsb/idmapper/backend/data/task/UniprotGroupCollectionTask.java
@@ -14,6 +14,10 @@ import java.util.List;
  * @author Yana Rose
  */
 public class UniprotGroupCollectionTask extends CollectionTask {
+    private static final String GROUP_PROVENANCE_FIELD =
+            CoreConstants.RCSB_GROUP_CONTAINER_IDENTIFIERS + "." + CoreConstants.GROUP_PROVENANCE_ID;
+    private static final Document FILTER = new Document(
+            GROUP_PROVENANCE_FIELD, Input.AggregationMethod.matching_uniprot_accession.name());
 
     public UniprotGroupCollectionTask(String collectionName, Repository r) {
         super(collectionName, r, List.of(
@@ -35,5 +39,18 @@ public class UniprotGroupCollectionTask extends CollectionTask {
             repository.getGroupRepository()
                     .addGroupMembers(Input.AggregationMethod.matching_uniprot_accession, null, group, members);
         };
+    }
+
+    @Override
+    protected Document getFilter() {
+        return FILTER;
+    }
+
+    @Override
+    public Runnable createCountRunnable(Long count) {
+        return () -> repository.addCount(
+                Repository.groupMetadataCountKey(Input.AggregationMethod.matching_uniprot_accession.name()),
+                count
+        );
     }
 }

--- a/src/test/java/org/rcsb/idmapper/test/backend/data/AggregationMethodProvenanceMapperTest.java
+++ b/src/test/java/org/rcsb/idmapper/test/backend/data/AggregationMethodProvenanceMapperTest.java
@@ -1,0 +1,36 @@
+package org.rcsb.idmapper.test.backend.data;
+
+import org.junit.jupiter.api.Test;
+import org.rcsb.idmapper.backend.data.AggregationMethodProvenanceMapper;
+import org.rcsb.idmapper.input.Input;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AggregationMethodProvenanceMapperTest {
+    @Test
+    public void methodToProvenanceToMethod_MustRoundTrip() {
+        for (Input.AggregationMethod method : Input.AggregationMethod.values()) {
+            String provenanceId = AggregationMethodProvenanceMapper.toProvenanceId(method);
+            assertEquals(method, AggregationMethodProvenanceMapper.toAggregationMethod(provenanceId));
+        }
+    }
+
+    @Test
+    public void methodToProvenance_MustBeUnique() {
+        Set<String> provenanceIds = Arrays.stream(Input.AggregationMethod.values())
+                .map(AggregationMethodProvenanceMapper::toProvenanceId)
+                .collect(Collectors.toSet());
+        assertEquals(Input.AggregationMethod.values().length, provenanceIds.size());
+    }
+
+    @Test
+    public void unknownProvenance_MustThrow() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AggregationMethodProvenanceMapper.toAggregationMethod("unknown_provenance"));
+    }
+}


### PR DESCRIPTION
- The `group_metadata` collection contains the content previously stored in four separate group collections.
- Added filtering by `group_provenance_id` to preserve the existing data retrieval flow and behavior.
- Introduced a centralized bi-directional mapping between `aggregation_method` and `group_provenance_id.`
- The IDMapper client continues to use `aggregation_method` as input. The IDMapper service translates the input to `group_provenance_id` for getting the results.
- Centralizing the mapping logic eliminates scattered hard-coded enum dependencies and simplifies future maintenance.

The PR passed all Postman tests. 